### PR TITLE
katietools: Fix Shader Node names for 2.67+

### DIFF
--- a/scripts/addons/katietools/tools_materials.py
+++ b/scripts/addons/katietools/tools_materials.py
@@ -259,22 +259,22 @@ def importMatcapImages(context):
                 tree = bpy.data.materials[matName].node_tree
                 links = tree.links
                 
-                geo = tree.nodes.new('GEOMETRY')
+                geo = tree.nodes.new('ShaderNodeGeometry')
                 geo.name = 'KTmc_Geometry'
                 geo.location = -200,0
                 
-                map = tree.nodes.new('MAPPING')
+                map = tree.nodes.new('ShaderNodeMapping')
                 map.name = 'KTmc_Mapping'
                 map.scale = (1.0,-1.0,1.0)
                 links.new(geo.outputs[5],map.inputs[0])
                 
-                tex = tree.nodes.new('TEXTURE')
+                tex = tree.nodes.new('ShaderNodeTexture')
                 tex.name = 'KTmc_Texture'
                 tex.location = 300,0
                 tex.texture = bpy.data.textures[texName]
                 links.new(map.outputs[0],tex.inputs[0])
                 
-                '''curve = tree.nodes.new('CURVE_RGB') #RGB Curve node for texture color space 'correction'
+                '''curve = tree.nodes.new('ShaderNodeRGBCurve') #RGB Curve node for texture color space 'correction'
                 curve.name = 'KTmc_CurveRGB'
                 curve.location = 500,0
                 cCurve = curve.mapping.curves[3] #the 'C' curve is first in the UI but last in the code

--- a/scripts/addons/katietools/tools_render.py
+++ b/scripts/addons/katietools/tools_render.py
@@ -605,28 +605,28 @@ class OBJECT_OT_cyclesMaterialFoundation(bpy.types.Operator):
         diffuse.inputs[0].default_value = diffColor
         diffuse.location = -235,300
         
-        glossy = tree.nodes.new('BSDF_GLOSSY')
+        glossy = tree.nodes.new('ShaderNodeBsdfGlossy')
         glossy.inputs[0].default_value = glossColor
         glossy.location = -235,150
         
-        mixShader = tree.nodes.new('MIX_SHADER')
+        mixShader = tree.nodes.new('ShaderNodeMixShader')
         mixShader.location = 40,340
         
-        layWeight = tree.nodes.new('LAYER_WEIGHT')
+        layWeight = tree.nodes.new('ShaderNodeLayerWeight')
         layWeight.location = -1080,300
         
-        ramp = tree.nodes.new('VALTORGB')
+        ramp = tree.nodes.new('ShaderNodeValToRGB')
         ramp.location = -800,300
         ramp.color_ramp.interpolation = 'B_SPLINE'
         elements = ramp.color_ramp.elements
         elements[0].position = rampPos1
         
-        mixA = tree.nodes.new('MIX_RGB')
+        mixA = tree.nodes.new('ShaderNodeMixRGB')
         mixA.location = -435,475
         mixA.inputs[1].default_value = mixA_col1
         mixA.inputs[2].default_value = mixA_col2
         
-        mixB = tree.nodes.new('MIX_RGB')
+        mixB = tree.nodes.new('ShaderNodeMixRGB')
         mixB.location = -435,150
         mixB.inputs[1].default_value = mixB_col1
         mixB.inputs[2].default_value = mixB_col2


### PR DESCRIPTION
Hopefully fixes the problems in 2.67+ (did not test)
